### PR TITLE
Fix backup alarms being printed with no players on server

### DIFF
--- a/src/main/java/ftb/utils/world/Backups.java
+++ b/src/main/java/ftb/utils/world/Backups.java
@@ -42,10 +42,6 @@ public class Backups
 		World w = FTBLib.getServerWorld();
 		if(w == null) return false;
 		
-		IChatComponent c = FTBU.mod.chatComponent("cmd.backup_start", ics.getCommandSenderName());
-		c.getChatStyle().setColor(EnumChatFormatting.LIGHT_PURPLE);
-		BroadcastSender.inst.addChatMessage(c);
-		
 		nextBackup = LMUtils.millis() + FTBUConfigBackups.backupMillis();
 		
 		if(auto && FTBUConfigBackups.need_online_players.getAsBoolean())
@@ -53,7 +49,11 @@ public class Backups
 			if(!FTBLib.hasOnlinePlayers() && !hadPlayer) return true;
 			hadPlayer = false;
 		}
-		
+
+		IChatComponent c = FTBU.mod.chatComponent("cmd.backup_start", ics.getCommandSenderName());
+		c.getChatStyle().setColor(EnumChatFormatting.LIGHT_PURPLE);
+		BroadcastSender.inst.addChatMessage(c);
+
 		try
 		{
 			new CommandSaveOff().processCommand(FTBLib.getServer(), new String[0]);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87545780/179351388-b64e8ff7-912f-466b-9056-41f3f6c2e5a1.png)
With config option "need_online_players" enabled backup notifications are still being sent, but no backups are actually made and this becomes misleading.
